### PR TITLE
Allow font tag to contain single-quote characters.

### DIFF
--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -1214,7 +1214,7 @@ function parse_bbc($message, $smileys = true, $cache_id = '', $parse_tags = arra
 			array(
 				'tag' => 'font',
 				'type' => 'unparsed_equals',
-				'test' => '[A-Za-z0-9_,\-\s\']+?\]',
+				'test' => '(([A-Za-z0-9_\-]+|&#39;.*&#39;),\s*)+([A-Za-z0-9_\-]+|&#39;.*&#39;)\]',
 				'before' => '<span style="font-family: $1;" class="bbc_font">',
 				'after' => '</span>',
 			),


### PR DESCRIPTION
For dealing with sceditor copy-paste font-family lists more gracefully.
Example: paste text from another web page, with "font-family: 'Segoe UI', Tahoma, sans-serif;"
http://www.simplemachines.org/community/index.php?topic=524219.msg3711839#msg3711839

In response to SimpleMachines:Smf2.1#1768

Signed-off-by: Angelina Belle angelinabelle1@hotmail.com
